### PR TITLE
Tools cli

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ end
 
 gem 'librarian-puppet'
 gem 'puppet', '< 4.0.0'
+gem 'clamp'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,5 +1,5 @@
 require 'yaml'
-require './lib/forklift'
+require './lib/forklift/box_loader'
 
 VAGRANTFILE_API_VERSION = '2'
 SUPPORT_SSH_INSERT_KEY = Gem.loaded_specs['vagrant'].version >= Gem::Version.create('1.7')

--- a/forklift.rb
+++ b/forklift.rb
@@ -7,6 +7,7 @@ require File.join(File.dirname(__FILE__), 'lib/forklift')
 class MainCommand < Clamp::Command
 
   subcommand "koji-task", "Create a local repository from a Koji scratch build", Forklift::Command::KojiTaskCommand
+  subcommand "local-repo", "Turn a directory into a local repository for use on the system", Forklift::Command::LocalRepoCommand
 
 end
 

--- a/forklift.rb
+++ b/forklift.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+require 'clamp'
+
+require File.join(File.dirname(__FILE__), 'lib/forklift')
+
+class MainCommand < Clamp::Command
+
+  subcommand "koji-task", "Create a local repository from a Koji scratch build", Forklift::Command::KojiTaskCommand
+
+end
+
+MainCommand.run

--- a/lib/forklift/commands/koji_task_command.rb
+++ b/lib/forklift/commands/koji_task_command.rb
@@ -1,0 +1,15 @@
+require 'clamp'
+
+module Forklift
+  module Command
+    class KojiTaskCommand < Clamp::Command
+
+      option "--task", "TASK", "Koji task ID(s)", :required => true, :multivalued => true
+
+      def execute
+        Forklift::Processors::KojiTaskProcessor.process(task_list)
+      end
+
+    end
+  end
+end

--- a/lib/forklift/commands/local_repo_command.rb
+++ b/lib/forklift/commands/local_repo_command.rb
@@ -1,0 +1,23 @@
+require 'clamp'
+
+module Forklift
+  module Command
+    class LocalRepoCommand < Clamp::Command
+
+      option "--name", "NAME", "Name for the local repository", :required => true
+      option "--path", "PATH", "Path to directory to turn into a local repository", :required => true
+      option "--priority", "PRIORITY", "Optionally specify the repositories priority"
+
+      def execute
+        repo_maker = Forklift::RepoMaker.new(
+          :name => @name,
+          :directory => @path,
+          :priority => @priority,
+        )
+
+        repo_maker.create
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Something I had been pondering for a bit, and am curious others thoughts given what it introduces dependency. Sometimes I find I want some of the functionality built here without having to run through all of the installer aspects. For example, I want to be able to take a Koji task and turn it into a repository or turn a local directory into a repository easily. This idea introduces a CLI for common development/debugging tasks and tools that are not tied to running the installer.