### PR TITLE
Enable ansible capsule install for dev environments

### DIFF
--- a/boxes.yaml.example
+++ b/boxes.yaml.example
@@ -8,3 +8,10 @@ centos7-devel:
 katello-remote-execution:
   box: centos7-katello-nightly
   installer: --enable-foreman-remote-execution
+
+centos7-capsule-devel:
+    box: centos7
+    ansible:
+      playbook: 'playbooks/capsule-dev.yml'
+      group: 'capsule'
+      server: 'centos7-devel'

--- a/playbooks/capsule-dev.yml
+++ b/playbooks/capsule-dev.yml
@@ -1,0 +1,12 @@
+---
+- hosts: server capsule
+  become: true
+  vars:
+    capsule_server_group: "server-{{ inventory_hostname }}"
+    capsule_server: "{{ groups[capsule_server_group][0] }}"
+  roles:
+    - foreman_repositories
+    - katello_repositories
+    - etc_hosts
+    - {role: capsule, foreman_directory: '/home/vagrant/foreman/config/', 
+       devel: True, base_foreman_directory: '/home/vagrant/foreman/'}

--- a/playbooks/roles/capsule/tasks/devel_install.yml
+++ b/playbooks/roles/capsule/tasks/devel_install.yml
@@ -1,0 +1,19 @@
+- name: 'get existing rails server pid'
+  command: cat {{ base_foreman_directory }}tmp/pids/server.pid
+  register: existing_rails_server
+  become_user: vagrant
+  ignore_errors: True
+  delegate_to: "{{ capsule_server }}"
+
+- name: 'check for rails server'
+  fail: msg="No rails server detected running on {{ capsule_server }},
+             please run `rails s` on {{ capsule_server }}"
+  when: existing_rails_server.rc != 0
+
+- name: 'Add group foreman'
+  group: name=foreman state=present
+  delegate_to: "{{ capsule_server }}"
+
+- name: 'Install foreman-installer-katello'
+  yum: name="foreman-installer-katello"
+  delegate_to: "{{ capsule_server }}"

--- a/playbooks/roles/capsule/tasks/install.yml
+++ b/playbooks/roles/capsule/tasks/install.yml
@@ -16,12 +16,12 @@
   lineinfile: dest=/etc/hosts regexp=".*{{ ansible_nodename }}$" line="{{ capsule_ip }} {{ ansible_nodename }}" state=present
 
 - name: 'Get oauth-consumer-key'
-  shell: grep oauth_consumer_key /etc/foreman/settings.yaml | cut -d ' ' -f 2
+  shell: grep oauth_consumer_key "{{ foreman_directory }}"settings.yaml | cut -d ' ' -f 2
   delegate_to: "{{ capsule_server }}"
   register: oauth_consumer_key
 
 - name: 'Get oauth-consumer-secret'
-  shell: grep oauth_consumer_secret /etc/foreman/settings.yaml | cut -d ' ' -f 2
+  shell: grep oauth_consumer_secret "{{ foreman_directory }}"settings.yaml | cut -d ' ' -f 2
   delegate_to: "{{ capsule_server }}"
   register: oauth_consumer_secret
 
@@ -31,8 +31,9 @@
   register: pulp_oauth_secret
 
 - name: 'Generate Certs'
-  command: capsule-certs-generate --capsule-fqdn {{ ansible_nodename }} --certs-tar {{ capsule_certs_tar }}
+  command: capsule-certs-generate --capsule-fqdn {{ ansible_nodename }} --certs-tar {{ capsule_certs_tar }} --disable-system-checks
   delegate_to: "{{ capsule_server }}"
+
 - name: 'Fetch Certs'
   delegate_to: "{{ capsule_server }}"
   fetch:
@@ -49,6 +50,11 @@
     name: '*'
     update_cache: yes
     state: latest
+
+- name: 'Change cert permissions'
+  file: path='/etc/pki/katello/private' mode=0775
+  delegate_to: "{{ capsule_server }}"
+  when: devel is defined and devel == true
 
 - name: 'Install Capsule Installer RPM'
   yum:

--- a/playbooks/roles/capsule/tasks/main.yaml
+++ b/playbooks/roles/capsule/tasks/main.yaml
@@ -1,4 +1,7 @@
 ---
+- include: devel_install.yml
+  when: (capsule_upgrade == False and devel is defined and devel == True)
+
 - include: install.yml
   when: capsule_upgrade == False
 

--- a/playbooks/roles/capsule/vars/main.yml
+++ b/playbooks/roles/capsule/vars/main.yml
@@ -1,3 +1,4 @@
 ---
 capsule_certs_tar: "/root/{{ ansible_nodename }}.tar.gz"
 capsule_ip: "{{ ansible_default_ipv4.address }}"
+foreman_directory: "/etc/foreman/"

--- a/playbooks/roles/common/defaults/main.yml
+++ b/playbooks/roles/common/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+release: "{{ ansible_distribution_version.split('.')[0] }}"
+version_map:
+  'nightly': 'nightly'
+  '3.0': '1.11'
+  '3.1': '1.12'
+katello_version: "{{ inventory_host.split('-')[-1] if inventory_hostname.split('-')[-1] in version_map.keys() else 'nightly' }}"
+foreman_version: "{{ version_map[katello_version] }}"


### PR DESCRIPTION
To use this functionality, add the following configuration to your boxes.yaml,
changing the hostnames as needed

To setup a capsule with an existing development environment
------------------------------------------------------------

* Add to existing development server's configuration in boxes.yaml
```
  ansible:
    group: 'server'
```
* Add capsule with development server's name in server to boxes.yaml:

```
foocapsule:
  box: centos7
  ansible:
    playbook: 'playbooks/capsule-dev.yml'
    group: 'capsule'
    server: 'foo'
```
* ssh into existing development server and ```rails s```
* spin up new capsule ```vagrant up foocapsule```

To setup a new development environment with a capsule
-----------------------------------------------------

* setup boxes.yaml

```
foo:
  box: centos7
  shell: 'yum -y install ruby && cd /vagrant && ./setup.rb'
  options: --scenario=katello-devel
  installer: --katello-devel-github-username <your-github-name> --disable-system-checks
  ansible:
    group: 'server'

foocapsule:
  box: centos7
  ansible:
    playbook: 'playbooks/capsule-dev.yml'
    group: 'capsule'
    server: 'foo'
```
* ```vagrant up foo```
* ssh into foo and ```rails s```
* ```vagrant up foocapsule```