### PR TITLE
Add vagrant-hostmanager support for automatically configuring /etc/hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The first step in using Vagrant to deploy an environment is to ensure that Vagra
      1. Ensure you have the prerequisites installed `sudo yum install ruby rubygems ruby-devel gcc`
      2. Vagrant 1.6.5+ can be downloaded and installed from [Vagrant Downloads](http://www.vagrantup.com/downloads.html)
    * For **Virtualbox**, Vagrant 1.6.5+ can be downloaded and installed from [Vagrant Downloads](http://www.vagrantup.com/downloads.html)
+   * For automatic management of host names install the `vagrant-hostmanager` plugin.
 1. Clone this repository - `git clone https://github.com/Katello/forklift.git`
 1. Enter the repository - `cd forklift`
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -128,6 +128,13 @@ module Forklift
 
 
   Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    if Vagrant.has_plugin?("vagrant-hostmanager")
+      config.hostmanager.enabled = true
+      config.hostmanager.manage_host = true
+      config.hostmanager.manage_guest = true
+      config.hostmanager.include_offline = true
+    end
+
     @boxes.each do |name, box|
       define_vm config, box
     end


### PR DESCRIPTION
Configure /etc/hosts on both the host and guest boxes automatically if the vagrant-hostmanager plugin is installed. 