### PR TITLE
Allow external roles to be installed to galaxy_roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ Gemfile.lock
 *.pyc
 user_playbooks/*.yml
 user_playbooks/*.yaml
+playbooks/galaxy_roles
+requirements.yml

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ static:
 
 Boxes can be further customized by declaring Ansible playbooks to be run during provisioning. One or more playbooks can be specified and will be executed sequentially. An ignored directory can be used to put playbooks into 'user_playbooks' without worrying about adding them during a git commit.
 
+Ansible roles may also be installed directly using the [`ansible-galaxy` command](http://docs.ansible.com/ansible/galaxy.html#the-ansible-galaxy-command-line-tool). These roles will be installed at `playbooks/galaxy_roles` and will be ignored by git. You may also specify roles in a `requirements.yml`, which you can use to install all desired roles with `ansible-galaxy install -r requirements.yml`
+
 ```
 ansible:
   box: centos7-katello-nightly

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,7 +2,7 @@
 callback_plugins = $PWD/playbooks/callback_plugins/
 nocows = 1
 inventory = $PWD/playbooks/inventory/vagrant.py
-roles_path = $PWD/playbooks/roles
+roles_path = $PWD/playbooks/galaxy_roles:$PWD/playbooks/roles
 retry_files_save_path = $HOME/.ansible/retry-files
 private_key_file = $HOME/.vagrant.d/insecure_private_key
 remote_user = vagrant

--- a/requirements.yml.example
+++ b/requirements.yml.example
@@ -1,0 +1,5 @@
+# from galaxy
+- src: yatesr.timezone
+
+# from GitHub
+- src: https://github.com/bennojoy/nginx


### PR DESCRIPTION
FYI: `ansible-galaxy` installs roles to the first role in your `roles_path`.

To test, try something like this:

```sh
ansible-galaxy install bennojoy.mysql
```