### PR TITLE
Add support for FreeIPA deployment

### DIFF
--- a/config/base_boxes.yaml
+++ b/config/base_boxes.yaml
@@ -98,6 +98,14 @@ boxes:
       variables:
         puppet_repositories_version: 4
 
+  centos7-freeipa-server:
+      box: centos7
+      memory: 1024
+      ansible:
+        playbook: 'playbooks/freeipa_server.yml'
+        group: 'freeipa_server'
+        server: 'centos7-katello-3.1'
+
   centos6-bats:
     box: centos6
     <<: *bats_shell

--- a/playbooks/freeipa_server.yml
+++ b/playbooks/freeipa_server.yml
@@ -1,0 +1,5 @@
+---
+- hosts: all
+  roles:
+    - etc_hosts
+    - freeipa_server

--- a/playbooks/roles/freeipa_server/defaults/main.yml
+++ b/playbooks/roles/freeipa_server/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+server_group: "server-{{ inventory_hostname }}"
+katello_server: "{{ groups[server_group][0] }}"
+
+freeipa_server_ip: "{{ ansible_eth0.ipv4.address }}"
+freeipa_server_realm: "EXAMPLE.COM"
+freeipa_server_domain: "example.com"
+freeipa_server_directory_manager_password: "changeme"
+freeipa_server_directory_admin_password: "changeme"
+freeipa_server_kerberos_principal: "admin"
+freeipa_server_realm_password: "changeme"

--- a/playbooks/roles/freeipa_server/tasks/install_freeipa_client.yml
+++ b/playbooks/roles/freeipa_server/tasks/install_freeipa_client.yml
@@ -1,0 +1,50 @@
+---
+- name: 'Add /etc/hosts record for FreeIPA'
+  become: true
+  delegate_to: "{{ katello_server }}"
+  lineinfile: dest=/etc/hosts regexp=".*{{ ansible_nodename }}$" line="{{ freeipa_server_ip }} {{ ansible_nodename }}" state=present
+
+- name: 'Install FreeIPA client and admintools'
+  become: true
+  delegate_to: "{{ katello_server }}"
+  yum: name=ipa-client,ipa-admintools state=latest
+
+- name: 'Register Foreman in FreeIPA'
+  become: true
+  delegate_to: "{{ katello_server }}"
+  shell: ipa-client-install --domain example.com --server {{ ansible_nodename }} --mkhomedir --fixed-primary --realm={{ freeipa_server_realm }} --force-join -p {{ freeipa_server_kerberos_principal }}@{{ freeipa_server_realm }} -w {{ freeipa_server_realm_password }} -U creates=/etc/krb5.keytab
+
+- name: 'Run foreman-prepare-realm'
+  become: true
+  delegate_to: "{{ katello_server }}"
+  shell: echo changeme | foreman-prepare-realm {{ freeipa_server_kerberos_principal }}@{{ freeipa_server_realm }} {{ katello_server }}.{{ freeipa_server_domain }} chdir=/root creates=/root/freeipa.keytab
+
+- name: 'Create HTTP principal'
+  become: true
+  delegate_to: "{{ katello_server }}"
+  shell: echo changeme | kinit {{ freeipa_server_kerberos_principal }}
+
+- name: 'Add the host'
+  become: true
+  delegate_to: "{{ katello_server }}"
+  shell: ipa host-add --ip-address {{ ansible_eth0.ipv4.address }} {{ katello_server }}.{{ freeipa_server_domain }}
+
+- name: 'Add the service'
+  become: true
+  delegate_to: "{{ katello_server }}"
+  shell: ipa service-add HTTP/{{ katello_server }}.{{ freeipa_server_domain }} --force
+
+- name: 'Get the keytab'
+  become: true
+  delegate_to: "{{ katello_server }}"
+  shell: ipa-getkeytab -s {{ ansible_nodename }} -p HTTP/{{ katello_server }}.{{ freeipa_server_domain }}@{{ freeipa_server_realm }} -k /etc/httpd/conf/ipa.keytab
+
+- name: 'Copy the keytab'
+  become: true
+  delegate_to: "{{ katello_server }}"
+  shell: cp /root/freeipa.keytab /etc/foreman-proxy/freeipa.keytab && chown foreman-proxy /etc/foreman-proxy/freeipa.keytab && chmod 0600 /etc/foreman-proxy/freeipa.keytab
+
+- name: 'Enable Realm with foreman-installer'
+  become: true
+  delegate_to: "{{ katello_server }}"
+  shell: foreman-installer --foreman-proxy-realm=true

--- a/playbooks/roles/freeipa_server/tasks/install_freeipa_server.yml
+++ b/playbooks/roles/freeipa_server/tasks/install_freeipa_server.yml
@@ -1,0 +1,17 @@
+- name: 'Install FreeIPA server packages (this could take a while)'
+  yum: name=ipa-server,ipa-server-dns state=latest
+
+- name: 'Install Haveged (faster population of PRNG)'
+  yum: name=haveged state=latest
+
+- name: 'Start Haveged'
+  service: name=haveged state=started
+
+- name: 'Fix /etc/hosts record for self'
+  lineinfile: dest=/etc/hosts regexp=".*{{ ansible_nodename }}.*localhost.*" line="{{ freeipa_server_ip }} {{ ansible_nodename }}" state=present
+
+- name: 'Ensure localhost record is in /etc/hosts'
+  lineinfile: dest=/etc/hosts line="127.0.0.1 localhost.localdomain localhost" state=present
+
+- name: 'Run FreeIPA Install'
+  shell: ipa-server-install -U -r {{ freeipa_server_realm }} -p {{ freeipa_server_directory_manager_password }} -a {{ freeipa_server_directory_admin_password }} creates=/etc/krb5.keytab

--- a/playbooks/roles/freeipa_server/tasks/main.yml
+++ b/playbooks/roles/freeipa_server/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- include: install_freeipa_server.yml
+  become: true
+- include: install_freeipa_client.yml

--- a/playbooks/roles/katello_repositories/tasks/release_repos.yml
+++ b/playbooks/roles/katello_repositories/tasks/release_repos.yml
@@ -1,5 +1,6 @@
 ---
 - name: 'Setup Katello Repository'
+  become: true
   yum:
     name: https://fedorapeople.org/groups/katello/releases/yum/{{ katello_version }}/katello/el{{ ansible_distribution_major_version }}/x86_64/katello-repos-latest.rpm
     state: present


### PR DESCRIPTION
This deploys a FreeIPA instance, registers the Katello to it, and
configures Realm and an auth source in Katello.