### PR TITLE
More generic capsule_ip

### DIFF
--- a/playbooks/roles/capsule/vars/main.yml
+++ b/playbooks/roles/capsule/vars/main.yml
@@ -1,3 +1,3 @@
 ---
 capsule_certs_tar: "/root/{{ ansible_nodename }}.tar.gz"
-capsule_ip: "{{ ansible_eth0.ipv4.address }}"
+capsule_ip: "{{ ansible_default_ipv4.address }}"


### PR DESCRIPTION
We can't rely on the eth0 if the playbook used outside
of the vagrant environment