### PR TITLE
Allow custom user roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ Gemfile.lock
 .ruby-gemset
 *.retry
 *.pyc
-user_playbooks/*.yml
-user_playbooks/*.yaml
+user_playbooks
 playbooks/galaxy_roles
 requirements.yml

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,7 +2,7 @@
 callback_plugins = $PWD/playbooks/callback_plugins/
 nocows = 1
 inventory = $PWD/playbooks/inventory/vagrant.py
-roles_path = $PWD/playbooks/galaxy_roles:$PWD/playbooks/roles
+roles_path = $PWD/playbooks/galaxy_roles:$PWD/user_playbooks/roles:$PWD/playbooks/roles
 retry_files_save_path = $HOME/.ansible/retry-files
 private_key_file = $HOME/.vagrant.d/insecure_private_key
 remote_user = vagrant


### PR DESCRIPTION
This really helps users perfect local roles without changing the git repo, then when ready, move them into forklift by simply moving them into the `playbooks/roles` directory and submitting a PR.