### PR TITLE
add per-box disk size field

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ memory -- set the amount of memory (in megabytes) this box will consume
 cpus -- set the number of cpus this box will use
 hostname -- hostname to set on the box
 networks -- custom networks to use in addition to the management network
+disk_size -- specify the size (in gigabytes) of the box's virtual disk. This only sets the virtual disk size, so you will still need to resize partitions and filesystems manually.
 ```
 
 Entirely new boxes can be created that do not orginate from a box defined within the Vagrantfile. For example, if you had access to a RHEL Vagrant box:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -40,7 +40,7 @@ module Forklift
         network['options'] = network['options'].inject({}){ |memo,(k,v)| memo.update(k.to_sym => v) }
       end
 
-      if box.key?('shell') && !box['shell'].nil? 
+      if box.key?('shell') && !box['shell'].nil?
         machine.vm.provision :shell do |shell|
           shell.inline = box.fetch('shell')
           shell.privileged = false if box.key?('privileged')
@@ -97,6 +97,7 @@ module Forklift
           end
           p.cpus = box.fetch('cpus') if box.fetch('cpus', false)
           p.memory = box.fetch('memory') if box.fetch('memory', false)
+          p.machine_virtual_size = box.fetch('disk_size') if box.fetch('disk_size', false)
         end
       end
 


### PR DESCRIPTION
You can now include `disk_size` in `boxes.yaml` for your custom boxes.
Disk size is specified in gigabytes. This only sets the virtual disk size, so you will still need to resize partitions and filesystems manually.

Example:

```yaml
# boxes.yaml

devbox6:
  box: centos6-devel
  bridged: br0
  disk_size: 250
```