### PR TITLE
Refs #16101 - Remove unneeded lines from hammer_devel

### DIFF
--- a/playbooks/roles/hammer_devel/tasks/hammer.yml
+++ b/playbooks/roles/hammer_devel/tasks/hammer.yml
@@ -15,18 +15,6 @@
       gem 'hammer_cli_foreman', :path => '../hammer-cli-foreman'
       gem 'hammer_cli_foreman_tasks', :path => '../hammer-cli-foreman-tasks'
 
-- name: 'Remove hammer_cli_foreman in Gemfile'
-  lineinfile:
-    dest: ~/hammer-cli-katello/Gemfile
-    regexp: "gem 'hammer_cli_foreman'"
-    line: ''
-
-- name: 'Remove hammer_cli in Gemfile'
-  lineinfile:
-    dest: ~/hammer-cli-katello/Gemfile
-    regexp: "gem 'hammer_cli'"
-    line: ''
-
 - name: 'Install bundler'
   command: bash -lc 'gem install bundler'
 


### PR DESCRIPTION
With the git repo dependencies no longer part of the development group, these lines can be removed. The dependencies are required [here](https://git.io/v6EKT) already.

Requires https://github.com/Katello/hammer-cli-katello/pull/442