### PR TITLE
Fix broken dev box

### DIFF
--- a/lib/forklift/processors/installer_options_processor.rb
+++ b/lib/forklift/processors/installer_options_processor.rb
@@ -2,7 +2,7 @@ module Forklift
   module Processors
     module InstallerOptionsProcessor
       def self.process(args)
-        installer_options = args.fetch(:installer_options, '')
+        installer_options = args.fetch(:installer_options, '') + ' --disable-system-checks'
         devel_user = args.fetch(:devel_user, nil)
         deployment_dir = args.fetch(:deployment_dir, nil)
 
@@ -10,7 +10,7 @@ module Forklift
 
         directory = deployment_dir || "/home/#{devel_user}"
         "#{installer_options} --katello-devel-user=#{devel_user}"\
-        " --certs-group=#{devel_user} --katello-deployment-dir=#{directory} --disable-system-checks"
+        " --certs-group=#{devel_user} --katello-deployment-dir=#{directory}"
       end
     end
   end

--- a/test/lib/processors/installer_options_processor_test.rb
+++ b/test/lib/processors/installer_options_processor_test.rb
@@ -10,7 +10,7 @@ class TestInstallerOptionsProcessor < Minitest::Test
     installer_options = Forklift::Processors::InstallerOptionsProcessor.process(
       :installer_options => @installer_options
     )
-    assert_equal installer_options, @installer_options
+    assert_equal installer_options, @installer_options + ' --disable-system-checks'
   end
 
   def test_process_devel_user
@@ -18,8 +18,8 @@ class TestInstallerOptionsProcessor < Minitest::Test
       :installer_options => @installer_options,
       :devel_user => 'testuser'
     )
-    @installer_options = "#{@installer_options} --katello-devel-user=testuser"\
-        ' --certs-group=testuser --katello-deployment-dir=/home/testuser --disable-system-checks'
+    @installer_options = "#{@installer_options} --disable-system-checks --katello-devel-user=testuser"\
+        ' --certs-group=testuser --katello-deployment-dir=/home/testuser'
 
     assert_equal installer_options, @installer_options
   end


### PR DESCRIPTION
--disable-system-checks wasn't being added if user was using
default setup, it was only added if they changed devel-user.