### PR TITLE
Fix error when skipping installer in setup.rb

### DIFF
--- a/lib/forklift/processors/installer_options_processor.rb
+++ b/lib/forklift/processors/installer_options_processor.rb
@@ -2,7 +2,8 @@ module Forklift
   module Processors
     module InstallerOptionsProcessor
       def self.process(args)
-        installer_options = args.fetch(:installer_options, '') + ' --disable-system-checks'
+        installer_options = args.fetch(:installer_options, '')
+        installer_options += ' --disable-system-checks' if installer_options
         devel_user = args.fetch(:devel_user, nil)
         deployment_dir = args.fetch(:deployment_dir, nil)
 


### PR DESCRIPTION
Currently ./setup.rb --skip-installer returns:

```
/vagrant/lib/forklift/processors/installer_options_processor.rb:5:in `process': undefined method `+' for nil:NilClass (NoMethodError)
	from ./setup.rb:106:in `<main>'
```