### PR TITLE
Automated katello client installs for dev environment

### DIFF
--- a/boxes.yaml.example
+++ b/boxes.yaml.example
@@ -15,3 +15,11 @@ centos7-capsule-devel:
       playbook: 'playbooks/capsule-dev.yml'
       group: 'capsule'
       server: 'centos7-devel'
+
+katello-client:
+  box: centos7
+  ansible:
+    playbook: 'playbooks/katello_client.yml'
+    group: 'client'
+    server: 'centos7-devel'
+

--- a/playbooks/katello_client.yml
+++ b/playbooks/katello_client.yml
@@ -1,0 +1,9 @@
+- hosts: server client
+  become: true
+  vars:
+    client_server_group: "server-{{ inventory_hostname }}"
+    katello_server: "{{ groups[client_server_group][0] }}"
+  roles:
+    - etc_hosts
+    - katello_repositories
+    - katello_client

--- a/playbooks/roles/katello_client/defaults/main.yml
+++ b/playbooks/roles/katello_client/defaults/main.yml
@@ -1,0 +1,4 @@
+katello_client_organization: "Default_Organization"
+katello_client_environment: "Library"
+katello_client_username: "admin"
+katello_client_password: "changeme"

--- a/playbooks/roles/katello_client/tasks/main.yml
+++ b/playbooks/roles/katello_client/tasks/main.yml
@@ -1,0 +1,12 @@
+- name: 'Install subscription-manager'
+  yum: name=subscription-manager
+
+- name: 'Install bootstrap rpm'
+  command: 'rpm -Uvh http://{{ katello_server }}/pub/katello-ca-consumer-latest.noarch.rpm'
+
+- name: 'Register client with subscription-manager'
+  command: 'subscription-manager register --org={{ katello_client_organization }} --environment={{ katello_client_environment }} 
+            --username={{ katello_client_username }} --password={{ katello_client_password }}'
+
+- name: 'Install katello-agent'
+  yum: name=katello-agent


### PR DESCRIPTION
In boxes.yaml:

```
client1:
  box: centos7
  ansible:
    playbook: 'playbooks/katello_client.yml'
    group: 'client'
```
and add
```
  ansible:
    group: 'server'
```
to the main katello server