### PR TITLE
Add foreman 1.13 to setup.rb versions

### DIFF
--- a/setup.rb
+++ b/setup.rb
@@ -45,11 +45,11 @@ OptionParser.new do |opts|
     options[:deployment_dir] = dir
   end
 
-  opts.on("--version [VERSION]", ['nightly', '1.7', '1.8', '1.9', '1.10', '1.11', '1.12'], "Set the version of Foreman to install") do |version|
+  opts.on("--version [VERSION]", ['nightly', '1.7', '1.8', '1.9', '1.10', '1.11', '1.12', '1.13'], "Set the version of Foreman to install") do |version|
     options[:version] = version
   end
 
-  opts.on("--katello-version [KATELLO_VERSION]", ['nightly', '2.3', '2.4', '3.0', '3.1'], "Set the version of Katello to install") do |version|
+  opts.on("--katello-version [KATELLO_VERSION]", ['nightly', '2.3', '2.4', '3.0', '3.1', '3.2'], "Set the version of Katello to install") do |version|
     options[:katello_version] = version
   end
 


### PR DESCRIPTION
Trying to `vagrant up centos7-foreman-1.13` would fail without this :)