### PR TITLE
Fixes #16394 - Playbook for ostree

### DIFF
--- a/playbooks/katello_ostree.yml
+++ b/playbooks/katello_ostree.yml
@@ -1,0 +1,10 @@
+- hosts: all
+  become: true
+  roles:
+    - ostree_repositories
+    - puppet_repositories
+    - role: foreman_installer
+      foreman_installer_scenario: katello
+      foreman_installer_options_internal_use_only:
+        - "--disable-system-checks"
+        - "--katello-enable-ostree=true"

--- a/playbooks/katello_ostree_devel.yml
+++ b/playbooks/katello_ostree_devel.yml
@@ -1,0 +1,10 @@
+- hosts: all
+  become: true
+  roles:
+    - ostree_repositories
+    - puppet_repositories
+    - role: foreman_installer
+      foreman_installer_scenario:  katello-devel
+      foreman_installer_options_internal_use_only:
+        - "--disable-system-checks"
+        - "--katello-devel-enable-ostree=true"

--- a/playbooks/roles/ostree_repositories/tasks/main.yml
+++ b/playbooks/roles/ostree_repositories/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: 'enable-ostree-repo'
+  yum_repository:
+    name: atomic
+    description: Centos Atomic Build Repository
+    baseurl: http://buildlogs.centos.org/centos/7/atomic/x86_64/Packages/
+    gpgcheck: no


### PR DESCRIPTION
Added a play book entry to enable ostree setup while doing a dev or
regular install.

Need to add

```
devel-box:
  box: centos7
  shell: 'yum -y install ruby && cd /vagrant && ./setup.rb'
  options: --scenario=katello-devel  --koji-repos
  installer: '.....'
  ansible:
     playbook:
      - 'playbooks/katello_ostree.yml'
     group: 'server'
     variables:
         katello_devel: True
```
