### PR TITLE
Add timing profile plugin for playbooks

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,6 @@
 [defaults]
 callback_plugins = $PWD/playbooks/callback_plugins/
+callback_whitelist = profile_tasks
 nocows = 1
 inventory = $PWD/playbooks/inventory/vagrant.py
 roles_path = $PWD/playbooks/galaxy_roles:$PWD/user_playbooks/roles:$PWD/playbooks/roles


### PR DESCRIPTION
Gives output like this:

```
PLAY RECAP *********************************************************************
centos7-katello-p4-nightly : ok=13   changed=9    unreachable=0    failed=0

Thursday 29 September 2016  16:32:07 -0400 (0:00:00.036)       0:19:18.004 ****
===============================================================================
katello : Run installer ----------------------------------------------- 467.10s
katello : Update packages --------------------------------------------- 358.72s
katello : Install Katello RPM ----------------------------------------- 316.52s
katello : Install foreman-release-scl ----------------------------------- 5.24s
setup ------------------------------------------------------------------- 3.47s
epel_repositories : Setup Epel Repository ------------------------------- 1.80s
puppet_repositories : Setup Puppet 4 Repository ------------------------- 1.70s
katello_repositories : Setup Katello Repository ------------------------- 1.51s
foreman_repositories : Setup Foreman Repository ------------------------- 1.16s
etc_hosts : Build hosts file -------------------------------------------- 0.42s
foreman_repositories : include ------------------------------------------ 0.07s
katello_repositories : include ------------------------------------------ 0.06s
katello : include ------------------------------------------------------- 0.05s
puppet_repositories : Setup Puppet 3 Repository ------------------------- 0.05s
katello : include ------------------------------------------------------- 0.04s
foreman_repositories : include ------------------------------------------ 0.02s
katello_repositories : include ------------------------------------------ 0.01s
```