### PR TITLE
Fixes #16854 - Sets up Atomic Registry

### DIFF
--- a/playbooks/katello_atomic_registry.yml
+++ b/playbooks/katello_atomic_registry.yml
@@ -1,0 +1,4 @@
+- hosts: all
+  become: true
+  roles:
+    - atomic_registry

--- a/playbooks/roles/atomic_registry/defaults/main.yml
+++ b/playbooks/roles/atomic_registry/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+atomic_registry_upstream_tag: latest
+atomic_registry_upstream_image: "docker.io/projectatomic/atomic-registry-install:{{ atomic_registry_upstream_tag }}"
+atomic_registry_upstream_image_name: "projectatomic/atomic-registry-install:{{ atomic_registry_upstream_tag }}"
+
+atomic_registry_registry_image: docker.io/openshift/origin-docker-registry
+atomic_registry_registry_port: 5060
+
+atomic_registry_console_image: docker.io/cockpit/kubernetes
+atomic_registry_console_port: 9099
+
+atomic_registry_master_image: docker.io/openshift/origin
+atomic_registry_master_port: 8450
+
+

--- a/playbooks/roles/atomic_registry/tasks/main.yml
+++ b/playbooks/roles/atomic_registry/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+- name: 'install the docker package'
+  yum:
+    name: docker
+    state: latest
+
+- name: 'install the atomic package'
+  yum:
+    name: atomic
+    state: latest
+
+- name: 'install AR docker image'
+  docker_image:
+    name: "{{ atomic_registry_upstream_image }}"
+
+- name: 'install master script'
+  shell: atomic install "{{ atomic_registry_upstream_image_name }}"
+  environment:
+    REGISTRYPORT: "{{ atomic_registry_registry_port }}"
+    CONSOLEPORT: "{{ atomic_registry_console_port }}"
+    MASTERPORT: "{{ atomic_registry_master_port }}"
+    MASTERIMAGE: "{{ atomic_registry_master_image }}"
+    CONSOLEIMAGE: "{{ atomic_registry_console_image }}"
+    REGISTRYIMAGE: "{{ atomic_registry_registry_image }}"
+
+- name: 'enable AR services'
+  service: name=atomic-registry-master.service enabled=yes state=started
+
+- name: Wait untils docker containers have started
+  shell: docker ps|wc -l
+  register: result
+  until: result.stdout.find("4") != -1
+  retries: 30
+  delay: 15
+
+- name: Finish running the installer
+  shell: /var/run/setup-atomic-registry.sh


### PR DESCRIPTION
Playbook script to generate an atomic registry

```
ar-box:
box: centos7-katello-nightly
ansible:
  playbook:
  - 'playbooks/katello_atomic_registry.yml'
  group: 'server'
```
