### PR TITLE
Handle the new versions.yaml format

### DIFF
--- a/lib/forklift/repositories.rb
+++ b/lib/forklift/repositories.rb
@@ -34,7 +34,7 @@ module Forklift
     end
 
     def katello_version
-      @versions['mapping'][@version]
+      @versions['installers'].select { |scenario| scenario['foreman'] == @version }[0]['katello']
     end
 
     def cleanup


### PR DESCRIPTION
dd7e3bbacc9371523e8a010b8396483e51eaa7f0 introduced a regression when it
rewrote versions.yaml.

Reported in https://github.com/Katello/forklift/pull/318#issuecomment-260351002