### PR TITLE
katello-certs-check not found on devel install

### DIFF
--- a/playbooks/devel.yml
+++ b/playbooks/devel.yml
@@ -6,6 +6,7 @@
     foreman_installer_scenario: katello-devel
     foreman_installer_options_internal_use_only:
       - "--disable-system-checks"
+      - "--certs-skip-check"
       - "--katello-devel-github-username {{ katello_devel_github_username }}"
     foreman_installer_additional_packages:
       - foreman-installer-katello-devel


### PR DESCRIPTION
Since katello-certs-check is not found on the -devel installer, and a
hook (pre/20-certs_update.rb) uses it, let's skip the certs check as it
just throws an error on -devel.

Alternatively (and I'd prefer it) we could provide this tool + katello-service on devel installs too, I'm not sure why it's not on the package.