### PR TITLE
Instructions to run webpack-dev in HTTPS

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -10,6 +10,7 @@ This covers how to setup and configure a development environment using the Forkl
  * [Hammer Development](#hammer-development)
  * [Capsule Development](#capsule-development)
  * [Client Development](#client-development)
+ * [Webpack](#webpack)
 
 ## Development Environment Deployment
 
@@ -244,3 +245,33 @@ then add
 ```
 
 to the main katello server you want the client attached to
+
+## Webpack
+
+Forklift creates a reverse proxy between localhost:3000 (Rails development default server) and https://forkliftfqdn (e.g: https://centos7-devel.example.com). This will cause mixed-content errors if you try to enable the webpack server without any options, as it needs to use the right certificates for HTTPS and Foreman needs to allow it. If you do not need to hack on Webpack code, ensure `:webpack_dev_server` is set to false in `~/foreman/config/settings.yaml` and run `bundle exec rake webpack:compile` from `~/foreman`.That will create the necessary assets to be served by Foreman. If you want to work on Webpack code, follow these instructions:
+
+To work with webpack-dev-server, ensure the following lines are in your `~/foreman/config/settings.yaml`:
+
+```
+:webpack_dev_server: true
+:webpack_dev_server_https: true
+```
+
+This will instruct Foreman to use Webpack from an https source. Now we need to make sure Webpack is using the right certificates to serve the development content through HTTPS. We're going to save these configuration values on `~/foreman/.env`:
+
+```
+WEBPACK_OPTS='--https --key /etc/pki/katello/private/katello-default-ca.key --cert /etc/pki/katello/certs/katello-default-ca.crt --cacert /etc/pki/katello/certs/katello-default-ca.crt'
+```
+
+Remember to run `source ~/foreman/.env` before running your Webpack server, so that the right options to enable HTTPS are loaded.
+
+Additionally, Foreman uses [secureheaders](https://github.com/twitter/secureheaders) to protect users from different attacks. secureheaders will block requests to the webpack development server, as it's not running in localhost:3000. To allow it, change the following lines in `~/foreman/config/initializers/secure_headers.rb`, substituting centos7-devel.example.com for your fqdn, you can get this value by running `hostname -f`.
+
+```
+    :style_src   => ["'unsafe-inline'", "'self'", 'centos7-devel.example.com:3808'],
+    :script_src  => ["'unsafe-eval'", "'unsafe-inline'", "'self'", 'centos7-devel.example.com:3808'],
+```
+
+One last thing: Firefox will not like that webpack-dev-server is using a self-signed certificate. You should go to `https://centos7-devel.example.com:3008` (or your equivalent) and add an exception for this certificate. Chrome does not throw any warnings if you have accepted the same certificate already for `https://centos7-devel.example.com`.
+
+After these changes, you should be able to run the webpack development server alongside with Foreman. Try it out by going to `~/foreman` and running `foreman start`. Happy hacking!


### PR DESCRIPTION
Without this, webpack-dev-server does noto run in Forklift due to Apache 
forcing HTTPS on every connection, and Foreman will get mixed content
warnings.

I intend to automate this with Ansible at some point, but for the time being, let's have some instructions so people can develop using this already.