### PR TITLE
Use foreman_installer_admin_password directly

### DIFF
--- a/playbooks/katello.yml
+++ b/playbooks/katello.yml
@@ -11,6 +11,5 @@
       foreman_installer_scenario: katello
       foreman_installer_options_internal_use_only:
           - "--disable-system-checks"
-          - "--foreman-admin-password {{ foreman_installer_admin_password }}"
       foreman_installer_additional_packages:
           - katello

--- a/playbooks/roles/foreman_installer/tasks/install.yml
+++ b/playbooks/roles/foreman_installer/tasks/install.yml
@@ -3,6 +3,7 @@
   shell: >
       foreman-installer {{ (foreman_installer_verbose == True) | ternary("-v", "") }}
       --scenario "{{ foreman_installer_scenario }}"
+      --foreman-admin-password "{{ foreman_installer_admin_password }}"
       {{ foreman_installer_options }}
       {{ foreman_installer_options_internal_use_only | join(" ") }}
   when: not foreman_installer_skip_installer


### PR DESCRIPTION
It seemed foreman_installer was exposing the admin password setting, but
it was not used there (we relied on the katello to construct the
options). I believe using it directly would be more expectable.