### PR TITLE
Source bash to ensure puppet command is present

### DIFF
--- a/bats/fb-install-katello.bats
+++ b/bats/fb-install-katello.bats
@@ -96,6 +96,7 @@ setup() {
 }
 
 @test "wake up puppet agent" {
+  source ~/.bashrc
   puppet agent -t -v
 }
 


### PR DESCRIPTION
Trying to get nightly green (especially before we start making big changes like removing setup.rb). The current failure is `puppet command not found` when using Puppet 4.