### PR TITLE
Add client repo to koji repos for katello

### DIFF
--- a/playbooks/roles/katello_repositories/tasks/koji_repos.yml
+++ b/playbooks/roles/katello_repositories/tasks/koji_repos.yml
@@ -12,6 +12,14 @@
     priority: 1
     gpgcheck: 0
 
+- name: 'Katello Client Koji repository'
+  yum_repository:
+    name: katello-koji
+    description: "Katello {{ katello_version }} Client Koji Repository"
+    baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_version }}/client/el{{ ansible_distribution_major_version }}/x86_64/"
+    priority: 1
+    gpgcheck: 0
+
 - name: 'Candlepin Koji repository'
   yum_repository:
     name: candlepin-koji


### PR DESCRIPTION
Having swapped to using the Ansible playbook and roles, I think this is the missing piece to the failures:

http://ci.theforeman.org/view/Katello%20Pipeline/job/release_test_katello_nightly_el7/178/console