### PR TITLE
Name client koji repo properly

### DIFF
--- a/playbooks/roles/katello_repositories/tasks/koji_repos.yml
+++ b/playbooks/roles/katello_repositories/tasks/koji_repos.yml
@@ -14,7 +14,7 @@
 
 - name: 'Katello Client Koji repository'
   yum_repository:
-    name: katello-koji
+    name: katello-client-koji
     description: "Katello {{ katello_version }} Client Koji Repository"
     baseurl: "http://koji.katello.org/releases/yum/katello-{{ katello_version }}/client/el{{ ansible_distribution_major_version }}/x86_64/"
     priority: 1


### PR DESCRIPTION
Installation was failing due to two repositories with the same name
being laid down and thus Katello main repository wasn't available.