### PR TITLE
Default bats should be server tests only

### DIFF
--- a/playbooks/roles/bats/defaults/main.yaml
+++ b/playbooks/roles/bats/defaults/main.yaml
@@ -2,4 +2,4 @@
 bats_git_dir: "/root/bats"
 bats_forklift_dir: "/root/forklift"
 bats_update_forklift: "yes"
-bats_tests: "fb-install-katello.bats fb-content-katello.bats fb-proxy.bats fb-finish-katello.bats"
+bats_tests: "fb-install-katello.bats fb-content-katello.bats fb-finish-katello.bats"


### PR DESCRIPTION
The fb-proxy.bats tests are aimed at an external foreman proxy
and thus break when run on the server.