### PR TITLE
Ouput bats tests to tap output file

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -69,14 +69,12 @@ module Forklift
           @ansible_groups["server-#{box.fetch('name')}"] = box['ansible']['server']
         end
 
-        @host_vars = {box['name'] => box['ansible']['variables']}
-
         if (playbooks = box['ansible']['playbook'])
           [playbooks].flatten.each_with_index do |playbook, index|
             args = SUPPORT_NAMED_PROVISIONERS ? ["main#{index}", type: 'ansible'] : [:ansible]
             machine.vm.provision(*args) do |ansible|
               ansible.playbook = playbook
-              ansible.host_vars = @host_vars if @host_vars && Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
+              ansible.extra_vars = box['ansible']['variables'] if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
               ansible.groups = @ansible_groups
             end
           end

--- a/playbooks/roles/bats/defaults/main.yaml
+++ b/playbooks/roles/bats/defaults/main.yaml
@@ -1,5 +1,9 @@
 ---
 bats_git_dir: "/root/bats"
 bats_forklift_dir: "/root/forklift"
+bats_output_dir: "/root/bats_results"
 bats_update_forklift: "yes"
-bats_tests: "fb-install-katello.bats fb-content-katello.bats fb-finish-katello.bats"
+bats_tests:
+  - "fb-install-katello.bats"
+  - "fb-content-katello.bats"
+  - "fb-finish-katello.bats"

--- a/playbooks/roles/bats/tasks/main.yml
+++ b/playbooks/roles/bats/tasks/main.yml
@@ -21,7 +21,13 @@
     dest: "{{ bats_forklift_dir }}"
     update: "{{ bats_update_forklift }}"
 
+- name: "Bats output directory"
+  file:
+    state: "directory"
+    path: "{{ bats_output_dir }}"
+
 - name: "Run bats"
-  shell: "bats {{ bats_tests }}"
+  shell: "bats --tap {{ item }} > {{ bats_output_dir }}/{{ item }}.tap"
   args:
     chdir: "{{ bats_forklift_dir }}/bats"
+  with_items: "{{ bats_tests }}"


### PR DESCRIPTION
The idea is this will spit out an output file into `/root` per test that is run. Those results can then be scp'd off in Jenkins to feed into the TAP result plugin to trend over time and mark the build success or failure (very similar to what was done prior to the removal of setup.rb).