### PR TITLE
Add Pipeline definitions and ability to provision

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,4 @@ end
 
 gem 'librarian-puppet'
 gem 'puppet', '< 4.0.0'
+gem 'clamp'

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,16 +11,26 @@ SUPPORT_BOX_CHECK_UPDATE = Gem.loaded_specs['vagrant'].version >= Gem::Version.c
 VAGRANTFILE_DIR = File.dirname(__FILE__)
 
 module Forklift
+    
+  CURRENT_FILE = File.dirname(__FILE__)
 
   def self.plugin_base_boxes
-    current = File.dirname(__FILE__)
-    base_boxes = Dir.glob "#{current}/plugins/*/base_boxes.yaml"
+    base_boxes = Dir.glob "#{CURRENT_FILE}/plugins/*/base_boxes.yaml"
     base_boxes.each { |boxes| add_boxes(boxes) }
   end
 
+  def self.pipeline_boxes
+    loader = PipelineLoader.new("#{CURRENT_FILE}/pipelines")
+    loader.boxes.each { |boxes| add_boxes(boxes) }
+  end
+
+  def self.plugin_pipeline_boxes
+    loader = PipelineLoader.new("#{CURRENT_FILE}/plugins/*/pipelines")
+    loader.boxes.each { |boxes| add_boxes(boxes) }
+  end
+
   def self.plugin_vagrantfiles
-    current = File.dirname(__FILE__)
-    Dir.glob "#{current}/plugins/*/Vagrantfile"
+    Dir.glob "#{CURRENT_FILE}/plugins/*/Vagrantfile"
   end
 
   def self.add_boxes(boxes)
@@ -125,6 +135,8 @@ module Forklift
   @boxes = @box_loader.add_boxes("#{VAGRANTFILE_DIR}/config/base_boxes.yaml", "#{VAGRANTFILE_DIR}/config/versions.yaml")
   plugin_vagrantfiles.each { |f| load f }
   plugin_base_boxes
+  pipeline_boxes
+  plugin_pipeline_boxes
   @boxes = @box_loader.add_boxes("#{VAGRANTFILE_DIR}/boxes.yaml", "#{VAGRANTFILE_DIR}/config/versions.yaml") if File.exists?("#{VAGRANTFILE_DIR}/boxes.yaml")
   @boxes  = @boxes.keys.sort.inject({}) do |hash, key|
     hash[key] = @boxes[key]

--- a/boxes.yaml.example
+++ b/boxes.yaml.example
@@ -5,7 +5,7 @@ centos7-devel:
     playbook: 'playbooks/devel.yml'
     group: 'devel'
     variables:
-      katello_devel_github_username: <REPLACE ME>
+      katello_devel_github_username: ehelms
 
 katello-remote-execution:
   box: centos7-katello-nightly

--- a/forklift
+++ b/forklift
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require 'clamp'
+
+require File.join(File.dirname(__FILE__), 'lib/forklift/command')
+
+class MainCommand < Clamp::Command
+  subcommand "pipeline", "Setup release environment for a given configuration", Forklift::Command::PipelineCommand
+end
+
+MainCommand.run

--- a/lib/forklift.rb
+++ b/lib/forklift.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift File.dirname(__FILE__)
 
 files = Dir[File.dirname(__FILE__) + '/forklift/**/*.rb']
-files.uniq.each { |f| require f }
+files.uniq.each { |f| require f unless f.include?('command') }
 
 module Forklift
 end

--- a/lib/forklift/box_loader.rb
+++ b/lib/forklift/box_loader.rb
@@ -10,15 +10,17 @@ module Forklift
       @shells = {}
     end
 
-    def add_boxes(box_file, version_file)
-      config = YAML.load_file(box_file)
+    def add_boxes(boxes, version_file)
+      if boxes.is_a?(String) && File.exist?(boxes)
+        config = YAML.load_file(boxes)
+      else
+        config = boxes
+      end
       return @boxes unless config
 
       versions = YAML.load_file(version_file)
 
-      process_shells(config['shells']) if config.key?('shells')
-
-      if config.key?('boxes')
+      if config.is_a?(Hash) && config.key?('boxes')
         process_versions(config, versions)
         process_boxes(config['boxes'])
       else

--- a/lib/forklift/command.rb
+++ b/lib/forklift/command.rb
@@ -1,0 +1,11 @@
+$LOAD_PATH.unshift File.dirname(__FILE__)
+
+require "#{File.dirname(__FILE__)}"
+
+files = Dir[File.dirname(__FILE__) + '/**/commands/*.rb']
+files.uniq.each { |f| require f }
+
+module Forklift
+  module Command
+  end
+end

--- a/lib/forklift/commands/helpers.rb
+++ b/lib/forklift/commands/helpers.rb
@@ -1,0 +1,18 @@
+module Forklift
+  module Command
+    module Helpers
+
+      def execute_command(command)
+        process = IO.popen("#{command} 2>&1") do |io|
+          while line = io.gets
+            line.chomp!
+            puts line
+          end
+          io.close
+          $?.success?
+        end
+      end
+
+    end
+  end
+end

--- a/lib/forklift/commands/pipeline_command.rb
+++ b/lib/forklift/commands/pipeline_command.rb
@@ -1,0 +1,80 @@
+require 'clamp'
+
+module Forklift
+  module Command
+    class UpCommand < Clamp::Command
+      include Command::Helpers
+
+      parameter "PIPELINE", "Name of the pipeline to run"
+
+      def execute
+        pipeline_loader = PipelineLoader.new
+        pipeline = pipeline_loader.pipeline(@pipeline)
+
+        unless pipeline
+          puts "No pipeline found for #{@pipeline}"
+          exit 1
+        end
+
+        pipeline.boxes.keys.each do |box|
+          execute_command("vagrant up #{box}")
+        end
+      end
+
+    end
+
+    class DestroyCommand < Clamp::Command
+      include Command::Helpers
+
+      parameter "PIPELINE", "Name of the pipeline to destroy"
+
+      def execute
+        pipeline_loader = PipelineLoader.new
+        pipeline = pipeline_loader.pipeline(@pipeline)
+        boxes = pipeline.boxes.keys.join(' ')
+        pipeline.boxes.keys.each do |box|
+          execute_command("vagrant destroy #{box}")
+        end
+      end
+
+    end
+
+    class ProvisionCommand < Clamp::Command
+      include Command::Helpers
+
+      parameter "PIPELINE", "Name of the pipeline to provision"
+
+      def execute
+        pipeline_loader = PipelineLoader.new
+        pipeline = pipeline_loader.pipeline(@pipeline)
+        boxes = pipeline.boxes.keys.join(' ')
+        pipeline.playbooks.each do |playbook|
+          success = execute_command("ansible-playbook #{pipeline.location}/#{playbook}")
+          exit 1 unless success
+        end
+      end
+
+    end
+
+    class ListCommand < Clamp::Command
+      include Command::Helpers
+
+      def execute
+        pipeline_loader = PipelineLoader.new
+        max_name_length = pipeline_loader.pipelines.map(&:name).max { |a, b| a.length <=> b.length }.length
+        pipeline_loader.pipelines.each do |pipeline|
+          puts [pipeline.name, (" " * (max_name_length - pipeline.name.length + 1)), pipeline.description].join(' ')
+        end
+      end
+
+    end
+
+    class PipelineCommand < Clamp::Command
+      subcommand "up", "Bring up the boxes necessary to run a pipeline", UpCommand
+      subcommand "destroy", "Destroy the boxes associated a pipeline", DestroyCommand
+      subcommand "provision", "Provision the playbooks associated to a pipeline", ProvisionCommand
+      subcommand "list", "List pipelines", ListCommand
+    end
+
+  end
+end

--- a/lib/forklift/pipeline_loader.rb
+++ b/lib/forklift/pipeline_loader.rb
@@ -1,0 +1,32 @@
+require 'yaml'
+
+module Forklift
+  class PipelineLoader
+
+    attr_reader :pipelines_directory, :pipelines
+
+    def initialize(pipelines_directory = nil)
+      @pipelines_directory = pipelines_directory || "pipelines"
+      @pipelines = []
+      load_pipelines
+    end
+
+    def load_pipelines
+      files = Dir.glob("#{@pipelines_directory}/**/pipeline.yaml")
+      @pipelines = files.collect do |file|
+        data = YAML.load_file(file)
+        data['location'] = File.dirname(file)
+        OpenStruct.new(data)
+      end
+    end
+
+    def pipeline(name)
+      @pipelines.find { |pipeline| pipeline.name == name }
+    end
+
+    def boxes
+      @pipelines.collect { |pipeline| pipeline.boxes }
+    end
+
+  end
+end

--- a/pipelines/3.3/install/bats_on_katello.yml
+++ b/pipelines/3.3/install/bats_on_katello.yml
@@ -1,0 +1,5 @@
+---
+- hosts: pipeline-katello-3.3-centos7
+  become: true
+  roles:
+    - bats

--- a/pipelines/3.3/install/bats_on_proxy.yml
+++ b/pipelines/3.3/install/bats_on_proxy.yml
@@ -1,0 +1,8 @@
+---
+- hosts: pipeline-proxy-3.3-centos7
+  become: true
+  vars:
+    bats_tests:
+      - fb-proxy.bats
+  roles:
+    - bats

--- a/pipelines/3.3/install/install_katello.yml
+++ b/pipelines/3.3/install/install_katello.yml
@@ -1,0 +1,20 @@
+---
+- hosts: pipeline-katello-3.3-centos7
+  become: yes
+  vars_files:
+    - vars.yml
+  vars:
+    foreman_installer_scenario: katello
+    foreman_installer_options_internal_use_only:
+      - "--disable-system-checks"
+      - "--foreman-admin-password {{ foreman_installer_admin_password }}"
+    foreman_installer_additional_packages:
+      - katello
+  roles:
+    - selinux
+    - etc_hosts
+    - epel_repositories
+    - puppet_repositories
+    - foreman_repositories
+    - katello_repositories
+    - foreman_installer

--- a/pipelines/3.3/install/install_proxy.yml
+++ b/pipelines/3.3/install/install_proxy.yml
@@ -1,0 +1,30 @@
+---
+- hosts: pipeline-proxy-3.3-centos7
+  become: yes
+  vars_files:
+    - vars.yml
+  vars:
+    foreman_proxy_content_server: pipeline-katello-3.3-centos7
+    foreman_installer_scenario: foreman-proxy-content
+    foreman_installer_options_internal_use_only:
+      - '--disable-system-checks
+        --foreman-proxy-trusted-hosts "{{ server_fqdn.stdout }}"
+        --foreman-proxy-trusted-hosts "{{ ansible_nodename }}"
+        --foreman-proxy-foreman-base-url "https://{{ server_fqdn.stdout }}"
+        --foreman-proxy-register-in-foreman true
+        --foreman-proxy-oauth-consumer-key "{{ oauth_consumer_key.stdout }}"
+        --foreman-proxy-oauth-consumer-secret "{{ oauth_consumer_secret.stdout }}"
+        --foreman-proxy-content-certs-tar "{{ foreman_proxy_content_certs_tar }}"
+        --foreman-proxy-content-parent-fqdn "{{ server_fqdn.stdout }}"
+        --foreman-proxy-content-pulp-oauth-secret "{{ pulp_oauth_secret.stdout }}"'
+    foreman_installer_additional_packages:
+      - foreman-installer-katello
+  roles:
+    - selinux
+    - etc_hosts
+    - epel_repositories
+    - puppet_repositories
+    - foreman_repositories
+    - katello_repositories
+    - foreman_proxy_content
+    - foreman_installer

--- a/pipelines/3.3/install/pipeline.yaml
+++ b/pipelines/3.3/install/pipeline.yaml
@@ -1,0 +1,15 @@
+---
+name: install_33
+description: "Install Katello 3.3 with a Proxy and run bats tests"
+boxes:
+  pipeline-katello-3.3-centos7:
+    box: centos7
+    memory: 4680
+  pipeline-proxy-3.3-centos7:
+    box: centos7
+    memory: 3072
+playbooks:
+  - install_katello.yml
+  - install_proxy.yml
+  - bats_on_katello.yml
+  - bats_on_proxy.yml

--- a/pipelines/3.3/install/vars.yml
+++ b/pipelines/3.3/install/vars.yml
@@ -1,0 +1,5 @@
+---
+puppet_repositories_version: 4
+katello_version: 3.3
+foreman_version: 1.14
+katello_repositories_use_koji: true

--- a/pipelines/3.3/upgrade_31/bats_on_katello.yml
+++ b/pipelines/3.3/upgrade_31/bats_on_katello.yml
@@ -1,0 +1,5 @@
+---
+- hosts: pipeline-katello-3.3-centos7
+  become: true
+  roles:
+    - bats

--- a/pipelines/3.3/upgrade_31/bats_on_proxy.yml
+++ b/pipelines/3.3/upgrade_31/bats_on_proxy.yml
@@ -1,0 +1,8 @@
+---
+- hosts: pipeline-proxy-3.3-centos7
+  become: true
+  vars:
+    bats_tests:
+      - fb-proxy.bats
+  roles:
+    - bats

--- a/pipelines/3.3/upgrade_31/install_katello_31.yml
+++ b/pipelines/3.3/upgrade_31/install_katello_31.yml
@@ -1,0 +1,20 @@
+---
+- hosts: pipeline-katello-3.3-centos7
+  become: yes
+  vars:
+    puppet_repositories_version: 3
+    katello_version: 3.1
+    foreman_version: 1.12
+    foreman_installer_scenario: katello
+    foreman_installer_options_internal_use_only:
+      - "--foreman-admin-password {{ foreman_installer_admin_password }}"
+    foreman_installer_additional_packages:
+      - katello
+  roles:
+    - selinux
+    - etc_hosts
+    - epel_repositories
+    - puppet_repositories
+    - foreman_repositories
+    - katello_repositories
+    - foreman_installer

--- a/pipelines/3.3/upgrade_31/install_proxy_31.yml
+++ b/pipelines/3.3/upgrade_31/install_proxy_31.yml
@@ -1,0 +1,32 @@
+---
+- hosts: pipeline-proxy-3.3-centos7
+  become: yes
+  vars:
+    puppet_repositories_version: 3
+    foreman_proxy_content_server: pipeline-katello-3.3-centos7
+    katello_version: 3.1
+    foreman_version: 1.12
+    foreman_repositories_use_koji: true
+    katello_repositories_use_koji: true
+    foreman_installer_scenario: capsule
+    foreman_installer_options_internal_use_only:
+      - '--foreman-proxy-trusted-hosts "{{ server_fqdn.stdout }}"
+        --foreman-proxy-trusted-hosts "{{ ansible_nodename }}"
+        --foreman-proxy-foreman-base-url "https://{{ server_fqdn.stdout }}"
+        --foreman-proxy-register-in-foreman true
+        --foreman-proxy-oauth-consumer-key "{{ oauth_consumer_key.stdout }}"
+        --foreman-proxy-oauth-consumer-secret "{{ oauth_consumer_secret.stdout }}"
+        --capsule-certs-tar "{{ foreman_proxy_content_certs_tar }}"
+        --capsule-parent-fqdn "{{ server_fqdn.stdout }}"
+        --capsule-pulp-oauth-secret "{{ pulp_oauth_secret.stdout }}"'
+    foreman_installer_additional_packages:
+      - foreman-installer-katello
+  roles:
+    - selinux
+    - etc_hosts
+    - epel_repositories
+    - puppet_repositories
+    - foreman_repositories
+    - katello_repositories
+    - foreman_proxy_content
+    - foreman_installer

--- a/pipelines/3.3/upgrade_31/pipeline.yaml
+++ b/pipelines/3.3/upgrade_31/pipeline.yaml
@@ -1,0 +1,16 @@
+---
+name: upgrade_31_to_33
+description: "Installs Katello and Proxy 3.1 and then upgrades to 3.3"
+boxes:
+  pipeline-katello-3.3-centos7:
+    box: centos7
+    memory: 4680
+  pipeline-proxy-3.3-centos7:
+    box: centos7
+    memory: 3072
+playbooks:
+  - install_katello_31.yml
+  - install_proxy_31.yml
+  - bats_on_katello.yml
+  - bats_on_proxy.yml
+  - upgrade_katello.yml

--- a/pipelines/3.3/upgrade_31/upgrade_katello.yml
+++ b/pipelines/3.3/upgrade_31/upgrade_katello.yml
@@ -1,0 +1,17 @@
+---
+- hosts: pipeline-katello-3.3-centos7
+  become: true
+  vars:
+    foreman_version: 1.14
+    katello_version: 3.3
+    foreman_installer_upgrade: True
+    foreman_repositories_use_koji: True
+    katello_repositories_use_koji: True
+    foreman_installer_scenario: katello
+    foreman_installer_options_internal_use_only:
+      - "--disable-system-checks"
+  roles:
+    - puppet_repositories
+    - foreman_repositories
+    - katello_repositories
+    - foreman_installer

--- a/pipelines/3.3/upgrade_32/bats_on_katello.yml
+++ b/pipelines/3.3/upgrade_32/bats_on_katello.yml
@@ -1,0 +1,5 @@
+---
+- hosts: pipeline-katello-3.2-3.3-centos7
+  become: true
+  roles:
+    - bats

--- a/pipelines/3.3/upgrade_32/bats_on_proxy.yml
+++ b/pipelines/3.3/upgrade_32/bats_on_proxy.yml
@@ -1,0 +1,8 @@
+---
+- hosts: pipeline-proxy-3.2-3.3-centos7
+  become: true
+  vars:
+    bats_tests:
+      - fb-proxy.bats
+  roles:
+    - bats

--- a/pipelines/3.3/upgrade_32/install_katello_32.yml
+++ b/pipelines/3.3/upgrade_32/install_katello_32.yml
@@ -1,0 +1,21 @@
+---
+- hosts: pipeline-katello-3.2-3.3-centos7
+  become: yes
+  vars:
+    puppet_repositories_version: 3
+    katello_version: 3.2
+    foreman_version: 1.13
+    foreman_installer_scenario: katello
+    foreman_installer_options_internal_use_only:
+      - "--foreman-admin-password {{ foreman_installer_admin_password }}"
+      - "--disable-system-checks"
+    foreman_installer_additional_packages:
+      - katello
+  roles:
+    - selinux
+    - etc_hosts
+    - epel_repositories
+    - puppet_repositories
+    - foreman_repositories
+    - katello_repositories
+    - foreman_installer

--- a/pipelines/3.3/upgrade_32/install_proxy_32.yml
+++ b/pipelines/3.3/upgrade_32/install_proxy_32.yml
@@ -1,0 +1,32 @@
+---
+- hosts: pipeline-proxy-3.2-3.3-centos7
+  become: yes
+  vars:
+    puppet_repositories_version: 3
+    foreman_proxy_content_server: pipeline-katello-3.3-centos7
+    katello_version: 3.2
+    foreman_version: 1.13
+    foreman_repositories_use_koji: true
+    katello_repositories_use_koji: true
+    foreman_installer_scenario: capsule
+    foreman_installer_options_internal_use_only:
+      - '--foreman-proxy-trusted-hosts "{{ server_fqdn.stdout }}"
+        --foreman-proxy-trusted-hosts "{{ ansible_nodename }}"
+        --foreman-proxy-foreman-base-url "https://{{ server_fqdn.stdout }}"
+        --foreman-proxy-register-in-foreman true
+        --foreman-proxy-oauth-consumer-key "{{ oauth_consumer_key.stdout }}"
+        --foreman-proxy-oauth-consumer-secret "{{ oauth_consumer_secret.stdout }}"
+        --capsule-certs-tar "{{ foreman_proxy_content_certs_tar }}"
+        --capsule-parent-fqdn "{{ server_fqdn.stdout }}"
+        --capsule-pulp-oauth-secret "{{ pulp_oauth_secret.stdout }}"'
+    foreman_installer_additional_packages:
+      - foreman-installer-katello
+  roles:
+    - selinux
+    - etc_hosts
+    - epel_repositories
+    - puppet_repositories
+    - foreman_repositories
+    - katello_repositories
+    - foreman_proxy_content
+    - foreman_installer

--- a/pipelines/3.3/upgrade_32/pipeline.yaml
+++ b/pipelines/3.3/upgrade_32/pipeline.yaml
@@ -1,0 +1,16 @@
+---
+name: upgrade_32_to_33
+description: "Installs Katello and Proxy 3.1 and then upgrades to 3.3"
+boxes:
+  pipeline-katello-3.2-3.3-centos7:
+    box: centos7
+    memory: 4680
+  pipeline-proxy-3.2-3.3-centos7:
+    box: centos7
+    memory: 3072
+playbooks:
+  - install_katello_32.yml
+  - install_proxy_32.yml
+  - bats_on_katello.yml
+  - bats_on_proxy.yml
+  - upgrade_katello.yml

--- a/pipelines/3.3/upgrade_32/upgrade_katello.yml
+++ b/pipelines/3.3/upgrade_32/upgrade_katello.yml
@@ -1,0 +1,17 @@
+---
+- hosts: pipeline-katello-3.2-3.3-centos7
+  become: true
+  vars:
+    foreman_version: 1.14
+    katello_version: 3.3
+    foreman_installer_upgrade: True
+    foreman_repositories_use_koji: True
+    katello_repositories_use_koji: True
+    foreman_installer_scenario: katello
+    foreman_installer_options_internal_use_only:
+      - "--disable-system-checks"
+  roles:
+    - puppet_repositories
+    - foreman_repositories
+    - katello_repositories
+    - foreman_installer

--- a/playbooks/roles/bats/tasks/main.yml
+++ b/playbooks/roles/bats/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: "Ensure git is installed"
+  yum:
+    name: "git"
+    state: "present"
+
 - name: "Get /usr/bin/bats stat"
   stat:
     path: "/usr/bin/bats"

--- a/playbooks/roles/foreman_installer/defaults/main.yml
+++ b/playbooks/roles/foreman_installer/defaults/main.yml
@@ -2,7 +2,7 @@
 foreman_installer_additional_packages: []
 foreman_installer_admin_password: changeme
 foreman_installer_skip_installer: False
-foreman_installer_verbose: True
+foreman_installer_verbose: False
 foreman_installer_scenario: foreman
 
 # Comma-separated list of "organization/module/pr_number", e.g. "katello/foreman_proxy_content/37,katello/certs/34"

--- a/test/fixtures/pipelines/3.3/install/pipeline.yaml
+++ b/test/fixtures/pipelines/3.3/install/pipeline.yaml
@@ -1,0 +1,9 @@
+---
+name: "Katello 3.3 installation"
+boxes:
+  pipeline-katello-centos7:
+    box: centos7
+    memory: 4680
+  pipeline-capsule-centos7:
+    box: centos7
+    memory: 3072

--- a/test/fixtures/pipelines/3.3/install/playbook.yml
+++ b/test/fixtures/pipelines/3.3/install/playbook.yml
@@ -1,0 +1,41 @@
+---
+- hosts: localhost
+  tasks:
+    - name: 'Bring up box for Katello'
+      command: vagrant up pipeline-katello-3.1-centos7
+
+    - name: 'Bring up box for Capsule'
+      command: vagrant up pipeline-capsule-3.1-centos7
+
+    - name: 'Refresh inventory'
+      meta: refresh_inventory
+
+- hosts: pipeline-katello-3.1-centos7
+  become: yes
+  vars:
+    katello_version: 3.1
+    katello_foreman_version: 1.12
+    katello_repositories_use_koji: true
+  roles:
+    - etc_hosts
+    - foreman_repositories
+    - katello_repositories
+    - katello
+
+- hosts: pipeline-capsule-3.1-centos7
+  become: yes
+  vars:
+    capsule_server: pipeline-katello-3.1-centos7
+    katello_version: 3.1
+    foreman_version: 1.12
+    katello_repositories_use_koji: true
+  roles:
+    - etc_hosts
+    - foreman_repositories
+    - katello_repositories
+    - capsule
+
+- hosts: pipeline-katello-3.1-centos7
+  become: true
+  roles:
+    - bats

--- a/test/lib/box_loader_test.rb
+++ b/test/lib/box_loader_test.rb
@@ -7,13 +7,7 @@ class TestBoxLoader < Minitest::Test
   end
 
   def test_load
-    assert @box_loader.add_boxes('config/base_boxes.yaml', 'config/versions.yaml')
-  end
-
-  def test_centos7
-    boxes = @box_loader.add_boxes('config/base_boxes.yaml', 'config/versions.yaml')
-    assert_equal 'centos7-katello-nightly', boxes['centos7-katello-nightly']['name']
-    assert_equal 'centos/7', boxes['centos7-katello-nightly']['box_name']
+    assert @pipeline_loader.load
   end
 
 end

--- a/test/lib/pipelines_test.rb
+++ b/test/lib/pipelines_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+
+class TestPipelines < Minitest::Test
+
+  def setup
+    @pipeline_loader = Forklift::PipelineLoader.new('test/fixtures/pipelines')
+  end
+
+  def test_load
+    assert @pipeline_loader.load
+    assert_equal 1, @pipeline_loader.pipelines.length
+    assert_equal 2, @pipeline_loader.pipelines.first['boxes'].length
+  end
+
+end


### PR DESCRIPTION
I had this idea, and thought I would hack it up quickly to present for some thought. This is a way to handle the "pipelines" and more complex topologies in a more declarative way with similar syntax to that of Vagrant. I'd be curious thoughts when you compare it to pipelines as they are in https://github.com/Katello/forklift/pull/331

Some alternative ideas:

 1) Take this idea but build a true vagrant plugin for it (no idea the effort involved)
 2) Have the pipeline playbooks dynamically deploy box files to a known location (so that they are known by the Vagrantfile by the time vagrant up is run) and have fully self-contained, longer playbooks that attempt to define everything

Usage:

The idea is that you define a pipeline by a name, set of boxes, and set of playbooks all together. You can then do:

```
./forklift pipeline up install_33
,/forklift pipeline provision install_33
./forklift pipeline destroy install_33
```

This is in a way, a simplified version of the idea in https://github.com/CentOS-PaaS-SIG/linch-pin using our existing Vagrant infrastructure.