### PR TITLE
Add foreman_chaos role and functionality to devel

### DIFF
--- a/playbooks/devel.yml
+++ b/playbooks/devel.yml
@@ -16,3 +16,4 @@
     - foreman_repositories
     - katello_repositories
     - foreman_installer
+    - foreman_chaos

--- a/playbooks/roles/foreman_chaos/defaults/main.yml
+++ b/playbooks/roles/foreman_chaos/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+foreman_chaos_minute: 0
+foreman_chaos_hour: "*"
+foreman_chaos_weekday: "*"

--- a/playbooks/roles/foreman_chaos/files/foreman-chaos
+++ b/playbooks/roles/foreman_chaos/files/foreman-chaos
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+sleep_time = Random.new.rand(60)
+puts "Sleeping for #{sleep_time} minutes"
+sleep(sleep_time)
+
+service_list = `katello-service list`.split("\n")
+service_list = service_list.map { |service| service.split("enabled")[0].strip }
+service_list = service_list.map { |service| service.gsub(".service", "") }
+
+random_service = service_list[Random.new.rand(service_list.length - 1)]
+
+puts "Stopping #{random_service}"
+system("service #{random_service} stop")
+

--- a/playbooks/roles/foreman_chaos/tasks/main.yml
+++ b/playbooks/roles/foreman_chaos/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: 'Deploy chaos script'
+  copy:
+    src: "{{ role_path }}/files/foreman-chaos"
+    dest: "/usr/sbin/foreman-chaos"
+    mode: "u=rwx,g=rx,o=r"
+
+- name: 'Create cronjob'
+  cron:
+    state: "present"
+    user: "root"
+    name: "foreman chaos"
+    minute: "{{ foreman_chaos_minute }}"
+    hour: "{{ foreman_chaos_hour }}"
+    weekday: "{{ foreman_chaos_weekday }}"
+    job: "/usr/sbin/foreman-chaos"
+    cron_file: "foreman-chaos"


### PR DESCRIPTION
This idea is inspired by the Netflix Chaos Monkey idea, whereby we deploy a cron job that runs a script at random intervals and randomly brings down a service. The goal being to force developers to have to deal with services going down more often and build better resiliency into the application to handle these situations.