### PR TITLE
Bats test promote using from environment instead of version

### DIFF
--- a/bats/fb-content-katello.bats
+++ b/bats/fb-content-katello.bats
@@ -84,7 +84,7 @@ setup() {
 
 @test "promote content view" {
   hammer -u admin -p changeme content-view version promote  --organization="Test Organization" \
-    --content-view="Test CV" --to-lifecycle-environment="Test" --version 1
+    --content-view="Test CV" --to-lifecycle-environment="Test" --from-lifecycle-environment="Library"
 }
 
 @test "create activation key" {
@@ -182,7 +182,7 @@ EOF
 
 @test "promote content view" {
   hammer -u admin -p changeme content-view version promote  --organization="Test Organization" \
-    --content-view="Test CV" --to-lifecycle-environment="Test" --version 1
+    --content-view="Test CV" --to-lifecycle-environment="Test" --from-lifecycle-environment="Library"
 }
 
 @test "add puppetclass to host" {


### PR DESCRIPTION
The error in the pipeline was caused by http://projects.theforeman.org/issues/18444 where in the update to the bats test we introduced a second promote that still used `version=1`