### PR TITLE
Introduce Forklift role for spinning up pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Gemfile.lock
 user_playbooks
 playbooks/galaxy_roles
 requirements.yml
+.tmp_boxes

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -27,6 +27,15 @@ module Forklift
     @boxes = @box_loader.add_boxes(boxes, "#{VAGRANTFILE_DIR}/config/versions.yaml")
   end
 
+  def self.user_boxes
+    @boxes = @box_loader.add_boxes("#{VAGRANTFILE_DIR}/boxes.yaml", "#{VAGRANTFILE_DIR}/config/versions.yaml") if File.exists?("#{VAGRANTFILE_DIR}/boxes.yaml")
+  end
+
+  def self.tmp_boxes
+    boxes = Dir.glob "#{VAGRANTFILE_DIR}/.tmp_boxes/*.yaml"
+    boxes.each { |boxes| add_boxes(boxes) }
+  end
+
   def self.define_vm(config, box = {})
     config.vm.define box.fetch('name'), primary: box.fetch('default', false) do |machine|
       machine.vm.box = box.fetch('box_name')
@@ -125,7 +134,8 @@ module Forklift
   @boxes = @box_loader.add_boxes("#{VAGRANTFILE_DIR}/config/base_boxes.yaml", "#{VAGRANTFILE_DIR}/config/versions.yaml")
   plugin_vagrantfiles.each { |f| load f }
   plugin_base_boxes
-  @boxes = @box_loader.add_boxes("#{VAGRANTFILE_DIR}/boxes.yaml", "#{VAGRANTFILE_DIR}/config/versions.yaml") if File.exists?("#{VAGRANTFILE_DIR}/boxes.yaml")
+  user_boxes
+  tmp_boxes
   @boxes  = @boxes.keys.sort.inject({}) do |hash, key|
     hash[key] = @boxes[key]
     hash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -21,6 +21,16 @@ To execute the bats framework:
   1.  ./bats/bootstrap.sh
   2.  katello-bats
 
+## Pipeline Testing
+
+Under `playbooks/pipelines` are a series of playbooks designed around testing scenarios for various version of the Foreman and Katello stack. To run one:
+
+    ansible-playbook playbooks/pipelines/pipeline_katello_nightly -e "forklift_state=up"
+
+When you are finished with the test, you can tear down the associated infrastructure:
+    
+    ansible-playbook playbooks/pipelines/pipeline_katello_nightly -e "forklift_state=destroy"
+
 ## Client Testing With Docker
 
 The docker/clients directory contains setup and configuration to register clients via subscription-manager using an activation key and start katello-agent. Before using the client containers, Docker and docker-compose need to be installed and setup. On a Fedora based system (Fedora 23 or greater):

--- a/pipelines/pipeline_katello_30.yml
+++ b/pipelines/pipeline_katello_30.yml
@@ -1,22 +1,25 @@
 - hosts: localhost
-  tasks:
-    - name: 'Bring up box for Katello'
-      command: vagrant up pipeline-katello-3.1-centos7
+  vars:
+    forklift_name: pipeline-katello-3.0
+    forklift_boxes:
+      pipeline-katello-3.0-centos7:
+        box: centos7
+        memory: 4680
+      pipeline-proxy-3.0-centos7:
+        box: centos7
+        memory: 3072
+  roles:
+    - forklift
 
-    - name: 'Bring up box for Capsule'
-      command: vagrant up pipeline-capsule-3.1-centos7
-
-    - name: 'Refresh inventory'
-      meta: refresh_inventory
-
-- hosts: pipeline-katello-3.1-centos7
+- hosts: pipeline-katello-3.0-centos7
   become: yes
   vars:
-    katello_version: 3.1
-    foreman_version: 1.12
+    katello_version: 3.0
+    foreman_version: 1.11
     katello_repositories_use_koji: true
     foreman_installer_scenario: katello
     foreman_installer_options_internal_use_only:
+      - "--disable-system-checks"
       - "--foreman-admin-password {{ foreman_installer_admin_password }}"
     foreman_installer_additional_packages:
       - katello
@@ -28,16 +31,17 @@
     - katello_repositories
     - foreman_installer
 
-- hosts: pipeline-capsule-3.1-centos7
+- hosts: pipeline-capsule-3.0-centos7
   become: yes
   vars:
-    capsule_server: pipeline-katello-3.1-centos7
-    katello_version: 3.1
-    foreman_version: 1.12
+    capsule_server: pipeline-katello-3.0-centos7
+    katello_version: 3.0
+    foreman_version: 1.11
     katello_repositories_use_koji: true
     foreman_installer_scenario: capsule
     foreman_installer_options_internal_use_only:
-      - '--foreman-proxy-trusted-hosts "{{ server_fqdn.stdout }}"
+      - '--disable-system-checks
+        --foreman-proxy-trusted-hosts "{{ server_fqdn.stdout }}"
         --foreman-proxy-trusted-hosts "{{ ansible_nodename }}"
         --foreman-proxy-foreman-base-url "https://{{ server_fqdn.stdout }}"
         --foreman-proxy-register-in-foreman true
@@ -57,12 +61,12 @@
     - capsule
     - foreman_installer
 
-- hosts: pipeline-katello-3.1-centos7
+- hosts: pipeline-katello-3.0-centos7
   become: true
   roles:
     - bats
 
-- hosts: pipeline-capsule-3.1-centos7
+- hosts: pipeline-capsule-3.0-centos7
   become: true
   vars:
     bats_tests:

--- a/pipelines/pipeline_katello_31.yml
+++ b/pipelines/pipeline_katello_31.yml
@@ -1,28 +1,28 @@
 - hosts: localhost
-  tasks:
-    - name: 'Bring up box for Katello'
-      command: vagrant up pipeline-katello-3.2-centos7
+  vars:
+    forklift_name: pipeline-katello-3.1
+    forklift_boxes:
+      pipeline-katello-3.1-centos7:
+        box: centos7
+        memory: 4680
+      pipeline-proxy-3.1-centos7:
+        box: centos7
+        memory: 3072
+  roles:
+    - forklift
 
-    - name: 'Bring up box for Capsule'
-      command: vagrant up pipeline-proxy-3.2-centos7
-
-    - name: 'Refresh inventory'
-      meta: refresh_inventory
-
-- hosts: pipeline-katello-3.2-centos7
+- hosts: pipeline-katello-3.1-centos7
   become: yes
   vars:
-    katello_version: 3.2
-    foreman_version: 1.13
+    katello_version: 3.1
+    foreman_version: 1.12
     katello_repositories_use_koji: true
     foreman_installer_scenario: katello
     foreman_installer_options_internal_use_only:
-      - "--disable-system-checks"
       - "--foreman-admin-password {{ foreman_installer_admin_password }}"
     foreman_installer_additional_packages:
       - katello
   roles:
-    - selinux
     - etc_hosts
     - epel_repositories
     - puppet_repositories
@@ -30,43 +30,41 @@
     - katello_repositories
     - foreman_installer
 
-- hosts: pipeline-proxy-3.2-centos7
+- hosts: pipeline-capsule-3.1-centos7
   become: yes
   vars:
-    foreman_proxy_content_server: pipeline-katello-3.2-centos7
-    katello_version: 3.2
-    foreman_version: 1.13
+    capsule_server: pipeline-katello-3.1-centos7
+    katello_version: 3.1
+    foreman_version: 1.12
     katello_repositories_use_koji: true
     foreman_installer_scenario: capsule
     foreman_installer_options_internal_use_only:
-      - '--disable-system-checks
-        --foreman-proxy-trusted-hosts "{{ server_fqdn.stdout }}"
+      - '--foreman-proxy-trusted-hosts "{{ server_fqdn.stdout }}"
         --foreman-proxy-trusted-hosts "{{ ansible_nodename }}"
         --foreman-proxy-foreman-base-url "https://{{ server_fqdn.stdout }}"
         --foreman-proxy-register-in-foreman true
         --foreman-proxy-oauth-consumer-key "{{ oauth_consumer_key.stdout }}"
         --foreman-proxy-oauth-consumer-secret "{{ oauth_consumer_secret.stdout }}"
-        --capsule-certs-tar "{{ foreman_proxy_content_certs_tar }}"
+        --capsule-certs-tar "{{ capsule_certs_tar }}"
         --capsule-parent-fqdn "{{ server_fqdn.stdout }}"
         --capsule-pulp-oauth-secret "{{ pulp_oauth_secret.stdout }}"'
     foreman_installer_additional_packages:
       - foreman-installer-katello
   roles:
-    - selinux
     - etc_hosts
     - epel_repositories
     - puppet_repositories
     - foreman_repositories
     - katello_repositories
-    - foreman_proxy_content
+    - capsule
     - foreman_installer
 
-- hosts: pipeline-katello-3.2-centos7
+- hosts: pipeline-katello-3.1-centos7
   become: true
   roles:
     - bats
 
-- hosts: pipeline-proxy-3.2-centos7
+- hosts: pipeline-capsule-3.1-centos7
   become: true
   vars:
     bats_tests:

--- a/pipelines/pipeline_katello_31_to_33_upgrade.yml
+++ b/pipelines/pipeline_katello_31_to_33_upgrade.yml
@@ -1,15 +1,17 @@
 - hosts: localhost
-  tasks:
-    - name: 'Bring up box for Katello'
-      command: vagrant up pipeline-katello-3.1-centos7
+  vars:
+    forklift_name: pipeline-katello-3.1-3.3
+    forklift_boxes:
+      pipeline-katello-3.1-3.3-centos7:
+        box: centos7
+        memory: 4680
+      pipeline-proxy-3.1-3.3-centos7:
+        box: centos7
+        memory: 3072
+  roles:
+    - forklift
 
-    - name: 'Bring up box for Capsule'
-      command: vagrant up pipeline-proxy-3.1-centos7
-
-    - name: 'Refresh inventory'
-      meta: refresh_inventory
-
-- hosts: pipeline-katello-3.1-centos7
+- hosts: pipeline-katello-3.1-3.3-centos7
   become: yes
   vars:
     puppet_repositories_version: 3
@@ -31,11 +33,11 @@
     - katello_repositories
     - foreman_installer
 
-- hosts: pipeline-proxy-3.1-centos7
+- hosts: pipeline-proxy-3.1-3.3-centos7
   become: yes
   vars:
     puppet_repositories_version: 3
-    foreman_proxy_content_server: pipeline-katello-3.1-centos7
+    foreman_proxy_content_server: pipeline-katello-3.1-3.3-centos7
     katello_version: 3.1
     foreman_version: 1.12
     foreman_repositories_use_koji: true
@@ -63,7 +65,7 @@
     - foreman_proxy_content
     - foreman_installer
 
-- hosts: pipeline-katello-3.1-centos7
+- hosts: pipeline-katello-3.1-3.3-centos7
   become: true
   vars:
     foreman_version: 1.14
@@ -78,12 +80,12 @@
     - katello_repositories
     - foreman_installer
 
-- hosts: pipeline-katello-3.1-centos7
+- hosts: pipeline-katello-3.1-3.3-centos7
   become: true
   roles:
     - bats
 
-- hosts: pipeline-proxy-3.1-centos7
+- hosts: pipeline-proxy-3.1-3.3-centos7
   become: true
   vars:
     bats_tests:

--- a/pipelines/pipeline_katello_32.yml
+++ b/pipelines/pipeline_katello_32.yml
@@ -1,19 +1,21 @@
 - hosts: localhost
-  tasks:
-    - name: 'Bring up box for Katello'
-      command: vagrant up pipeline-katello-3.0-centos7
+  vars:
+    forklift_name: pipeline-katello-3.2
+    forklift_boxes:
+      pipeline-katello-3.2-centos7:
+        box: centos7
+        memory: 4680
+      pipeline-proxy-3.2-centos7:
+        box: centos7
+        memory: 3072
+  roles:
+    - forklift
 
-    - name: 'Bring up box for Capsule'
-      command: vagrant up pipeline-capsule-3.0-centos7
-
-    - name: 'Refresh inventory'
-      meta: refresh_inventory
-
-- hosts: pipeline-katello-3.0-centos7
+- hosts: pipeline-katello-3.2-centos7
   become: yes
   vars:
-    katello_version: 3.0
-    foreman_version: 1.11
+    katello_version: 3.2
+    foreman_version: 1.13
     katello_repositories_use_koji: true
     foreman_installer_scenario: katello
     foreman_installer_options_internal_use_only:
@@ -22,6 +24,7 @@
     foreman_installer_additional_packages:
       - katello
   roles:
+    - selinux
     - etc_hosts
     - epel_repositories
     - puppet_repositories
@@ -29,12 +32,12 @@
     - katello_repositories
     - foreman_installer
 
-- hosts: pipeline-capsule-3.0-centos7
+- hosts: pipeline-proxy-3.2-centos7
   become: yes
   vars:
-    capsule_server: pipeline-katello-3.0-centos7
-    katello_version: 3.0
-    foreman_version: 1.11
+    foreman_proxy_content_server: pipeline-katello-3.2-centos7
+    katello_version: 3.2
+    foreman_version: 1.13
     katello_repositories_use_koji: true
     foreman_installer_scenario: capsule
     foreman_installer_options_internal_use_only:
@@ -45,26 +48,27 @@
         --foreman-proxy-register-in-foreman true
         --foreman-proxy-oauth-consumer-key "{{ oauth_consumer_key.stdout }}"
         --foreman-proxy-oauth-consumer-secret "{{ oauth_consumer_secret.stdout }}"
-        --capsule-certs-tar "{{ capsule_certs_tar }}"
+        --capsule-certs-tar "{{ foreman_proxy_content_certs_tar }}"
         --capsule-parent-fqdn "{{ server_fqdn.stdout }}"
         --capsule-pulp-oauth-secret "{{ pulp_oauth_secret.stdout }}"'
     foreman_installer_additional_packages:
       - foreman-installer-katello
   roles:
+    - selinux
     - etc_hosts
     - epel_repositories
     - puppet_repositories
     - foreman_repositories
     - katello_repositories
-    - capsule
+    - foreman_proxy_content
     - foreman_installer
 
-- hosts: pipeline-katello-3.0-centos7
+- hosts: pipeline-katello-3.2-centos7
   become: true
   roles:
     - bats
 
-- hosts: pipeline-capsule-3.0-centos7
+- hosts: pipeline-proxy-3.2-centos7
   become: true
   vars:
     bats_tests:

--- a/pipelines/pipeline_katello_33.yml
+++ b/pipelines/pipeline_katello_33.yml
@@ -1,13 +1,15 @@
 - hosts: localhost
-  tasks:
-    - name: 'Bring up box for Katello'
-      command: vagrant up pipeline-katello-3.3-centos7
-
-    - name: 'Bring up box for Capsule'
-      command: vagrant up pipeline-proxy-3.3-centos7
-
-    - name: 'Refresh inventory'
-      meta: refresh_inventory
+  vars:
+    forklift_name: pipeline-katello-3.3
+    forklift_boxes:
+      pipeline-katello-3.3-centos7:
+        box: centos7
+        memory: 4680
+      pipeline-proxy-3.3-centos7:
+        box: centos7
+        memory: 3072
+  roles:
+    - forklift
 
 - hosts: pipeline-katello-3.3-centos7
   become: yes

--- a/pipelines/pipeline_katello_nightly.yml
+++ b/pipelines/pipeline_katello_nightly.yml
@@ -1,13 +1,15 @@
 - hosts: localhost
-  tasks:
-    - name: 'Bring up box for Katello'
-      command: vagrant up pipeline-katello-centos7
-
-    - name: 'Bring up box for Capsule'
-      command: vagrant up pipeline-proxy-centos7
-
-    - name: 'Refresh inventory'
-      meta: refresh_inventory
+  vars:
+    forklift_name: pipeline-katello-nightly
+    forklift_boxes:
+      pipeline-katello-nightly-centos7:
+        box: centos7
+        memory: 4680
+      pipeline-proxy-nightly-centos7:
+        box: centos7
+        memory: 3072
+  roles:
+    - forklift
 
 - hosts: pipeline-katello-centos7
   become: yes

--- a/playbooks/roles/forklift/defaults/main.yml
+++ b/playbooks/roles/forklift/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+forklift_state: ''

--- a/playbooks/roles/forklift/tasks/main.yml
+++ b/playbooks/roles/forklift/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+- set_fact:
+    current_directory: "{{ lookup('pipe','dirname `pwd`') }}"
+
+- name: 'Check variables defined'
+  fail:
+    msg: 'Please define forklift_name which determines the file boxes are deployed to'
+  when: forklift_name is undefined
+
+- name: 'Check Forklift state'
+  fail:
+    msg: 'The forklift_state variable is undefined. Please use pass "-e "forklift_state=up"" to spin up the boxes or "-e "forklift_state=destroy"" to destroy the boxes'
+  when: forklift_state is undefined
+
+- name: 'Ensure .tmp_boxes directory'
+  file:
+    state: directory
+    path: "{{ current_directory }}/.tmp_boxes"
+
+- name: 'Write box file'
+  copy:
+    dest: "{{ current_directory }}/.tmp_boxes/{{ forklift_name }}.yaml"
+    content: "{{ forklift_boxes | to_yaml }}"
+
+- name: 'Bring up boxes'
+  command: "vagrant up {{ item.key }}"
+  args:
+    chdir: "{{ current_directory }}"
+  with_dict: "{{ forklift_boxes }}"
+  when: forklift_state == "up"
+
+- name: 'Destroy boxes'
+  command: "vagrant destroy {{ item.key }}"
+  args:
+    chdir: "{{ current_directory }}"
+  with_dict: "{{ forklift_boxes }}"
+  when: forklift_state == "destroy"
+
+- name: 'Remove box file'
+  file:
+    path: "{{ current_directory }}/.tmp_boxes/{{ forklift_name }}.yaml"
+    state: "absent"
+  when: forklift_state == "destroy"
+
+- name: 'Refresh inventory'
+  meta: refresh_inventory


### PR DESCRIPTION
This is take 2 on providing a bit more ease of use for defining and spinning up what we call pipelines and would replace the design from https://github.com/Katello/forklift/pull/381. The idea here is to introduce a small role that deploys temporary box files based on the boxes defined for the role to be used by the other plays. The boxes can be spin up or destroyed through the single playbook. 

The PR includes a pipeline file as an example. The idea would be to apply this to whats defined in https://github.com/Katello/forklift/pull/331

Example:

Create boxes and provision:
```
ansible-playbook playbooks/pipeline_katello_32.yml -e "forklift_state=up"
```

Destroy pipeline:
```
ansible-playbook playbooks/pipeline_katello_32.yml -e "forklift_state=destroy"
```