### PR TITLE
Adjust swap size to fix bats tests

### DIFF
--- a/bats/swapfile.bats
+++ b/bats/swapfile.bats
@@ -4,7 +4,7 @@
 set -o pipefail
 
 @test "create swap file" {
-  swapsize=4096 # in MB
+  swapsize=5120 # in MB
   dd if=/dev/zero of=/swapfile bs=1048576 count=$swapsize
   chmod 600 /swapfile
   mkswap /swapfile


### PR DESCRIPTION
The CI tests have been failing on katello-agent actions, sometimes with memory related errors.